### PR TITLE
Centre the sidebar with flexbox

### DIFF
--- a/style.css
+++ b/style.css
@@ -412,6 +412,13 @@ a.pagination-item:hover {
 		bottom: 0;
 		width: 18rem;
 		text-align: left;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+	.admin-bar #secondary {
+		top: 32px;
 	}
 }
 
@@ -421,10 +428,7 @@ a.pagination-item:hover {
 
 @media (min-width: 48rem) {
 	#secondary .container {
-		position: absolute;
-		top: 50%;
-		display: table-cell;
-		vertical-align: middle;
+		overflow: auto;
 	}
 }
 


### PR DESCRIPTION
Let's centre the sidebar with flexbox rather than absolute positioning. This is a bit more flexible, and means that you won't have the issue with the menu starting halfway down and overflowing the page.
