### PR TITLE
Remove the comment html help text

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -64,6 +64,12 @@ if ( post_password_required() ) {
 		<p class="no-comments"><?php _e( 'Comments are closed.', 'handbook' ); ?></p>
 	<?php endif; ?>
 
-	<?php comment_form(); ?>
+	<?php
+		comment_form(
+			array(
+				'comment_notes_after' => '',
+			)
+		);
+	?>
 
 </div><!-- #comments -->


### PR DESCRIPTION
It's stupid!

```html
You may use these HTML tags and attributes: <a href="" title=""> <abbr title=""> <acronym title=""> <b> <blockquote cite=""> <cite> <code> <del datetime=""> <em> <i> <q cite=""> <strike> <strong>
```
