### PR TITLE
Images should be constrained to container

### DIFF
--- a/style.css
+++ b/style.css
@@ -213,6 +213,7 @@ img {
 	display: block;
 	margin: 0 0 1rem;
 	border-radius: 5px;
+	max-width: 100%;
 }
 
 /* Tables */


### PR DESCRIPTION
If you add an image that's larger than the content container, it will currently overflow it.

We should add a `max-width: 100%` to these images.